### PR TITLE
Avoid downloading morpho-deepsulci models if they are present

### DIFF
--- a/scripts/bv_get_morpho_deepsulci_models.py
+++ b/scripts/bv_get_morpho_deepsulci_models.py
@@ -67,7 +67,7 @@ destdir = options.output
 if os.path.exists(destdir) and os.listdir(destdir):
     context.write('skipping download:', destdir, 'exists and is not empty.')
     sys.exit(0)
-else:
+elif not os.path.exists(destdir):
     os.makedirs(destdir)
 context.write('install in dir:', destdir)
 

--- a/scripts/bv_get_morpho_deepsulci_models.py
+++ b/scripts/bv_get_morpho_deepsulci_models.py
@@ -64,7 +64,10 @@ print('timeout:', timeout)
 context = Context()
 
 destdir = options.output
-if not os.path.exists(destdir):
+if os.path.exists(destdir) and os.listdir(destdir):
+    context.write('skipping download:', destdir, 'exists and is not empty.')
+    sys.exit(0)
+else:
     os.makedirs(destdir)
 context.write('install in dir:', destdir)
 


### PR DESCRIPTION
This avoids wasting bandwidth, and also allows to do offline builds.

However, the current fix does NOT check if the models are up-to-date, neither
if they are corrupted. We should add a checksum validation mechanism before
skipping the download.

@denisri Should we include the checksum directly in the download script?